### PR TITLE
[14.0]add herd on res_partner

### DIFF
--- a/animal_prescription/README.rst
+++ b/animal_prescription/README.rst
@@ -1,0 +1,1 @@
+to be updated

--- a/animal_prescription/__init__.py
+++ b/animal_prescription/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/animal_prescription/__manifest__.py
+++ b/animal_prescription/__manifest__.py
@@ -1,0 +1,32 @@
+# © 2023 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Animal Prescriptions",
+    "version": "14.0.1.0.0",
+    "category": "Sales",
+    "website": "https://github.com/OCA/vertical-agriculture",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["bealav"],
+    "license": "AGPL-3",
+    "installable": True,
+    "summary": "Management of prescriptions for veterinarians",
+    "depends": [
+        "herd",
+        "sale_management",
+        "animal_medicament",
+        "sale_order_lot_selection",
+        "product_expiry_simple",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/sale.xml",
+        "views/product.xml",
+        "views/physiology.xml",
+        "views/herd.xml",
+    ],
+    "demo": [
+        "data/physiology.csv",
+        "data/settings.xml",
+    ],
+}

--- a/animal_prescription/data/physiology.csv
+++ b/animal_prescription/data/physiology.csv
@@ -1,0 +1,5 @@
+"id","name"
+"0_","1 year less"
+"0_1","From 1 to 2 years"
+"2_3","From 2 to 3 years"
+"3_","More than 3 years"

--- a/animal_prescription/data/settings.xml
+++ b/animal_prescription/data/settings.xml
@@ -1,0 +1,10 @@
+<odoo>
+
+    <record id="base.user_admin" model="res.users">
+        <field
+            name="groups_id"
+            eval="[(4, ref('stock.group_production_lot')), (4, ref('product.group_product_pricelist')), (4, ref('product.group_sale_pricelist')), (4, ref('base.group_multi_company'))]"
+        />
+    </record>
+
+</odoo>

--- a/animal_prescription/models/__init__.py
+++ b/animal_prescription/models/__init__.py
@@ -1,0 +1,4 @@
+from . import sale
+from . import sale_line
+from . import physiology
+from . import posology

--- a/animal_prescription/models/physiology.py
+++ b/animal_prescription/models/physiology.py
@@ -1,0 +1,17 @@
+# © 2023 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import fields, models
+
+
+class Physiology(models.Model):
+    _name = "physiology"
+    _description = "Physiology"
+    _order = "sequence"
+
+    name = fields.Char()
+    sequence = fields.Integer()
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [("name_unique", "UNIQUE(name)", "Field name must be unique")]

--- a/animal_prescription/models/posology.py
+++ b/animal_prescription/models/posology.py
@@ -1,0 +1,11 @@
+# © 2023 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import fields, models
+
+
+class Posology(models.Model):
+    _inherit = "posology"
+
+    physiology_id = fields.Many2one(comodel_name="physiology")

--- a/animal_prescription/models/sale.py
+++ b/animal_prescription/models/sale.py
@@ -1,0 +1,20 @@
+# © 2023 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    herd_id = fields.Many2one(comodel_name="herd", string="Herd")
+    animal_ids = fields.Many2many(comodel_name="animal", string="Animals")
+    total_quantity = fields.Float(
+        compute="_compute_total_quantity", help="Used on report"
+    )
+    specie_id = fields.Many2one(related="herd_id.specie_id")
+
+    @api.depends("order_line.product_uom_qty")
+    def _compute_total_quantity(self):
+        for rec in self:
+            rec.total_quantity = sum(rec.order_line.mapped("product_uom_qty"))

--- a/animal_prescription/models/sale.py
+++ b/animal_prescription/models/sale.py
@@ -18,3 +18,10 @@ class SaleOrder(models.Model):
     def _compute_total_quantity(self):
         for rec in self:
             rec.total_quantity = sum(rec.order_line.mapped("product_uom_qty"))
+
+    @api.onchange("partner_id")
+    def _onchange_default_herd_id(self):
+        if self.partner_id and len(self.partner_id.herd_ids) == 1:
+            self.herd_id = self.partner_id.herd_ids.id
+        else:
+            self.herd_id = False

--- a/animal_prescription/models/sale_line.py
+++ b/animal_prescription/models/sale_line.py
@@ -1,0 +1,96 @@
+# © 2023 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from collections import defaultdict
+
+from odoo import api, fields, models
+
+from odoo.addons.animal_medicament.models.posology_mixin import MEAT, MILK
+
+
+class SaleOrderLine(models.Model):
+    _name = "sale.order.line"
+    _inherit = ["sale.order.line", "posology.mixin"]
+
+    unit_milk = fields.Selection(selection=MILK)
+    unit_meat = fields.Selection(selection=MEAT)
+    animal_count = fields.Integer(string="Headcount", help="Animals number")
+    animal_ids = fields.Many2many(comodel_name="animal", string="Animals")
+    physiology_id = fields.Many2one(comodel_name="physiology")
+    posology_id = fields.Many2one(
+        comodel_name="posology", compute="_compute_posology", store=True
+    )
+    poso_description = fields.Text()
+    specie_id = fields.Many2one(comodel_name="animal.species")
+    parent_specie_id = fields.Many2one(related="order_id.herd_id.specie_id")
+    lot_name = fields.Char(related="lot_id.name")
+    lot_date = fields.Date(related="lot_id.expiry_date")
+    product_tracking = fields.Selection(related="product_id.tracking")
+    milk_time_str = fields.Char(
+        string="Milk Delay",
+        compute="_compute_time_fields",
+        readonly=False,
+        store=True,
+        help="Waiting time for milk case by unit",
+    )
+    meat_time_str = fields.Char(
+        string="Meat Delay",
+        compute="_compute_time_fields",
+        readonly=False,
+        store=True,
+        copy=False,
+        help="Waiting time for meat case by unit",
+    )
+
+    @api.depends(
+        "product_id", "physiology_id", "order_id.herd_id", "milk_time", "meat_time"
+    )
+    def _compute_time_fields(self):
+        for rec in self:
+            rec.milk_time_str = rec.milk_time
+            rec.meat_time_str = rec.meat_time
+
+    @api.depends("product_id", "physiology_id", "order_id.herd_id")
+    def _compute_posology(self):
+        poso_prd = defaultdict(dict)
+        order = self[0].order_id
+        if order and order.herd_id:
+            products = self.mapped("product_id")
+            posos = self.env["posology"].search(
+                self._get_posology_domain(products),
+                order="product_id, physiology_id DESC",
+            )
+            for poso in posos:
+                if poso.description:
+                    poso_prd[poso.product_id][poso.physiology_id or "no"] = poso
+        for rec in self:
+            if rec.product_id in poso_prd:
+                posology = poso_prd[rec.product_id].get(rec.physiology_id) or poso_prd[
+                    rec.product_id
+                ].get("no")
+                rec.posology_id = posology or False
+                rec.unit_milk = posology.unit_milk
+                rec.milk_time = posology.milk_time
+                rec.unit_meat = posology.unit_meat
+                rec.meat_time = posology.meat_time
+                rec.poso_description = posology.description
+            else:
+                rec.posology_id = False
+
+    def _get_posology_domain(self, products):
+        return [
+            ("product_id", "in", products.ids),
+            ("specie_id", "child_of", self[0].order_id.herd_id.specie_id.id),
+        ]
+
+    def get_animals(self):
+        for rec in self:
+            rec.animal_ids = rec.order_id.animal_ids
+
+    def get_sale_order_line_multiline_description_sale(self, product):
+        res = super().get_sale_order_line_multiline_description_sale(product)
+        if res and res[:1] == "[":
+            pos = res.find("]")
+            if pos != -1:
+                res = res[pos + 2 :]
+        return res

--- a/animal_prescription/readme/DESCRIPTION.rst
+++ b/animal_prescription/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Management of prescriptions for veterinarians

--- a/animal_prescription/security/ir.model.access.csv
+++ b/animal_prescription/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_physiology_user,physiology.user,model_physiology,base.group_user,1,1,1,1

--- a/animal_prescription/views/herd.xml
+++ b/animal_prescription/views/herd.xml
@@ -1,0 +1,13 @@
+<odoo>
+
+    <record id="view_herd_tree" model="ir.ui.view">
+        <field name="model">herd</field>
+        <field name="inherit_id" ref="herd.view_herd_tree" />
+        <field name="arch" type="xml">
+            <field name="breed_id" position="after">
+                <field name="animal_ids" optional="hide" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/animal_prescription/views/physiology.xml
+++ b/animal_prescription/views/physiology.xml
@@ -1,0 +1,31 @@
+<odoo>
+
+    <record id="view_physiology_tree" model="ir.ui.view">
+        <field name="model">physiology</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom">
+                <field name="sequence" widget="handle" />
+                <field name="name" options="{'editable': 1}" />
+                <field name="active" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_physiology" model="ir.actions.act_window">
+        <field name="name">Etat physiologique</field>
+        <field name="res_model">physiology</field>
+        <field name="view_mode">tree</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+        id="physiology_menu"
+        action="action_physiology"
+        sequence="70"
+        parent="animal.menu_config"
+    />
+
+</odoo>

--- a/animal_prescription/views/product.xml
+++ b/animal_prescription/views/product.xml
@@ -1,0 +1,13 @@
+<odoo>
+
+    <record id="posology_tree_view" model="ir.ui.view">
+        <field name="model">posology</field>
+        <field name="inherit_id" ref="animal_medicament.posology_tree_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='specie_id']" position="after">
+                <field name="physiology_id" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/animal_prescription/views/sale.xml
+++ b/animal_prescription/views/sale.xml
@@ -1,0 +1,78 @@
+<odoo>
+
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="priority" eval="100" />
+        <field name="arch" type="xml">
+
+            <field name="sale_order_template_id" position="before">
+                <field
+                    name="herd_id"
+                    domain="[('partner_id', '=', partner_id)]"
+                    context="{'default_partner_id': partner_id}"
+                />
+                <field name="specie_id" invisible="1" />
+                <field
+                    name="animal_ids"
+                    widget="many2many_tags"
+                    domain="['|', '&amp;', ('herd_id', '=', False), ('partner_id', '=', partner_id), '&amp;', ('herd_id', '=', herd_id), ('herd_id', '!=', False)]"
+                    context="{'default_partner_id': partner_id, 'default_herd_id': herd_id, 'default_species_id': specie_id}"
+                />
+            </field>
+            <xpath
+                expr="//notebook/page[@name='order_lines']//tree/field[@name='lot_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'required': [('product_tracking', 'in', ('lot', 'serial'))]}</attribute>
+            </xpath>
+            <xpath
+                expr="//notebook/page[@name='order_lines']//tree/field[@name='name']"
+                position="after"
+            >
+                <field
+                    name="animal_ids"
+                    optional="show"
+                    widget="many2many_tags"
+                    domain="['|', '&amp;', ('herd_id', '=', False), ('partner_id', '=', parent.partner_id), '&amp;', ('herd_id', '=', parent.herd_id), ('herd_id', '!=', False)]"
+                />
+                <button name="get_animals" icon="fa-users" type="object" />
+                <field name="animal_count" optional="show" />
+                <field
+                    name="specie_id"
+                    optional="show"
+                    domain="[('id', 'child_of', parent_specie_id)]"
+                />
+                <field name="physiology_id" optional="show" />
+                <field name="poso_description" optional="show" />
+                <field name="posology_id" optional="hide" />
+                <field name="milk_time_str" optional="hide" />
+                <field name="unit_milk" optional="hide" />
+                <field name="meat_time_str" optional="hide" />
+                <field name="unit_meat" optional="hide" />
+                <field name="parent_specie_id" invisible="1" />
+                <field name="product_tracking" invisible="1" />
+            </xpath>
+        </field>
+    </record>
+
+    <menuitem id="sale.sale_menu_root" name="Prescription" />
+
+    <record id="sale.action_orders" model="ir.actions.act_window">
+        <field name="domain" eval="False" />
+    </record>
+
+    <record id="view_order_tree" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_tree" />
+        <field name="arch" type="xml">
+            <field name="state" position="after">
+                <field name="herd_id" optional="hide" />
+                <field name="animal_ids" optional="hide" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/herd/__manifest__.py
+++ b/herd/__manifest__.py
@@ -18,6 +18,7 @@
         "views/animal.xml",
         "views/herd.xml",
         "views/specie.xml",
+        "views/res_partner.xml",
         "data/animal_species.xml",
         "security/ir.model.access.csv",
     ],

--- a/herd/models/__init__.py
+++ b/herd/models/__init__.py
@@ -1,3 +1,4 @@
 from . import herd
 from . import animal
 from . import specie
+from . import res_partner

--- a/herd/models/res_partner.py
+++ b/herd/models/res_partner.py
@@ -1,0 +1,29 @@
+# copyright 2022 Syera BONNEAUX @ Akretion
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.depends("herd_ids")
+    def _compute_herd_count(self):
+        for rec in self:
+            rec.herd_count = len(rec.herd_ids)
+
+    herd_ids = fields.One2many(
+        comodel_name="herd", inverse_name="partner_id", string="Herds"
+    )
+    herd_count = fields.Integer(
+        compute=_compute_herd_count, string="Number of herds", store=True
+    )
+
+    def action_view_herds(self):
+        xmlid = "herd.action_herd"
+        action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
+        if self.herd_count > 1:
+            action["domain"] = [("id", "in", self.herd_ids.ids)]
+        else:
+            action["views"] = [(self.env.ref("herd.view_herd_form").id, "form")]
+            action["res_id"] = self.herd_ids and self.herd_ids.ids[0] or False
+        return action

--- a/herd/readme/CONTIBUTORS.rst
+++ b/herd/readme/CONTIBUTORS.rst
@@ -1,3 +1,4 @@
 * Akretion
 
     - David BEAL
+    - Syera BONNEAUX

--- a/herd/views/res_partner.xml
+++ b/herd/views/res_partner.xml
@@ -1,0 +1,25 @@
+<odoo>
+
+    <!-- Partner Form View -->
+    <record id="view_partner_herd_owner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button
+                    class="oe_stat_button"
+                    type="object"
+                    name="action_view_herds"
+                    icon="fa-pencil-square-o"
+                    context="{'default_partner_id': id}"
+                >
+                    <div class="o_stat_info">
+                        <field name="herd_count" class="o_stat_value" />
+                        <span class="o_stat_text"> Herds</span>
+                    </div>
+                </button>
+            </div>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/animal_prescription/odoo/addons/animal_prescription
+++ b/setup/animal_prescription/odoo/addons/animal_prescription
@@ -1,0 +1,1 @@
+../../../../animal_prescription

--- a/setup/animal_prescription/setup.py
+++ b/setup/animal_prescription/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo14-addon-product_expiry_simple @ git+https://github.com/OCA/stock-logistics-workflow.git@refs/pull/1271/head#subdirectory=setup/product_expiry_simple


### PR DESCRIPTION
@bealdav To be able to correctly automatize the field herd_id on a sale_order, i add an One2many field in a res_partner model in relation to the field partner_id in a herd model.  
this way, i add this 2 changes : 
- I can call the field herd_ids in a res_partner's model in my sale_order (in a module animal_prescription)
- We can choose a res_partner and in this model, there is a link to the herd on the chosen res_partner

@LESTRAT21 you can see in this picture the change in a res_partner model.
In a module animal_prescription, i add the automatic field on a sale_order
![herd_on_res_partner](https://user-images.githubusercontent.com/114986278/229852264-f0e4089e-f056-4376-9001-cea9df8693ff.png)
